### PR TITLE
Create only one UDP socket

### DIFF
--- a/src/truckerpath/clj_datadog/core.clj
+++ b/src/truckerpath/clj_datadog/core.clj
@@ -28,13 +28,14 @@
 
 ;; UDP helper
 
+(def udp-socket (delay (DatagramSocket.)))
+
 (defn- send-msg
   [conn-spec data]
   (let [{:keys [host port]} (conn conn-spec)
         ip-address (InetAddress/getByName host),
-        packet (DatagramPacket. (.getBytes data) (.length data) ip-address port)
-        socket (DatagramSocket.)]
-    (.send socket packet)))
+        packet (DatagramPacket. (.getBytes data) (.length data) ip-address port)]
+    (.send @udp-socket packet)))
 
 ;; StatsD client functions
 


### PR DESCRIPTION
Currently one is created per metric report. That can cause port exhaustion if GC isn't run frequently enough (especially if the receiving side is a userspace proxy - e.g. docker).